### PR TITLE
feat(relayedConnection): add ordering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AutoRelay is meant to be *plug and play* with TypeGraphQL and TypeORM (*more orm
 @ObjectType()
 class User {
   @OneToMany(() => Recipe)
-  @RelayConnection(() => Recipe)
+  @RelayedConnection(() => Recipe)
   recipes: Recipe[];
 }
 ```
@@ -143,6 +143,25 @@ This will auto-magically create a few GraphQL types, such as `UserRecipeConnecti
 
 Our TypeORM integration gets the repository for `Recipe`, translates the ConnectionArguments to an offset/limit tuple and fetches recipes connected to this `User`.
 
+
+#### Sorting results
+@RelayedConnection can optionally accept an order parameter in its options, that will allow you to fetch while sorting on the column of your entities. For example, if we wanted to get our recipes by best ratings :
+
+```typescript
+export class User {
+  @PrimaryGeneratedColumn()
+  @Field(() => ID)
+  id: number;
+
+  @Column()
+  @Field()
+  name: string;
+
+  @OneToMany(() => Recipe)
+  @RelayedConnection(() => Recipe, { order: { rating: 'DESC' } })
+  recipes: Recipe[]
+}
+```
 
 ### Making a Query Relayable
 Let's imagine we now have an `users` query, that we want to paginate using Relay. AutoRelay offers a few helpers with that.

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
     "packages/*"
   ],
   "version": "0.6.3",
+  "hoist": true,
   "publish": {
     "conventionalCommits": true,
     "message": "chore(release): automatic version tagging"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5066,7 +5066,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5481,7 +5482,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5537,6 +5539,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5580,12 +5583,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/core/src/decorators/relayed-connection.decorator.spec.ts
+++ b/packages/core/src/decorators/relayed-connection.decorator.spec.ts
@@ -42,15 +42,40 @@ describe('RelayedConnection', () => {
 
       process.nextTick(() => {
         expect(autoRelayFactory.mock.calls).toContainAllValues([
-          ['testLinked', expect.anything(), toTest, undefined],
-          ['testLinkedThrough', expect.anything(), toTest, toTestLink]
+          ['testLinked', expect.anything(), toTest, undefined, undefined],
+          ['testLinkedThrough', expect.anything(), toTest, toTestLink, undefined]
         ])
 
         cb();
       })
     })
 
-    it('StestClassTypehould create a getter on the class', (cb) => {
+    it('Should pass correct options to the orm factory', (cb) => {
+      class TestLinked { }
+      class TestLinkedThrough { }
+      const testClassType = class TestClass {
+        testLinked: TestLinked | undefined
+        testLinkedThrough: TestLinked | undefined
+      }
+
+      const toTest = () => TestLinked;
+      const toTestLink = () => TestLinkedThrough;
+      const options = {test:"test"} as any;
+
+      RelayedConnection(toTest, options)(testClassType.prototype, 'testLinked')
+      RelayedConnection(toTest, toTestLink, options)(testClassType.prototype, 'testLinkedThrough')
+
+      process.nextTick(() => {
+        expect(autoRelayFactory.mock.calls).toContainAllValues([
+          ['testLinked', expect.anything(), toTest, undefined, options],
+          ['testLinkedThrough', expect.anything(), toTest, toTestLink, options]
+        ])
+
+        cb();
+      })
+    })
+
+    it('Should create a getter on the class', (cb) => {
       class TestLinked { }
       class TestLinkedThrough { }
       const testClassType = class TestClass {

--- a/packages/core/src/decorators/relayed-connection.decorator.ts
+++ b/packages/core/src/decorators/relayed-connection.decorator.ts
@@ -4,9 +4,19 @@ import { MethodAndPropDecorator, ClassValueThunk } from '../types/types'
 import { DynamicObjectFactory } from '../graphql/dynamic-object.factory'
 
 export function RelayedConnection(type: ClassValueThunk): MethodAndPropDecorator
+export function RelayedConnection<T=any>(type: ClassValueThunk<T>, options: RelayedConnectionOptions<T>): MethodAndPropDecorator
 export function RelayedConnection(type: ClassValueThunk, through: ClassValueThunk): MethodAndPropDecorator
-export function RelayedConnection (type: ClassValueThunk, through?: ClassValueThunk): MethodAndPropDecorator {
+export function RelayedConnection<T=any>(type: ClassValueThunk, through: ClassValueThunk<T>, options: RelayedConnectionOptions<T>): MethodAndPropDecorator
+export function RelayedConnection (type: ClassValueThunk, throughOrOptions?: ClassValueThunk | RelayedConnectionOptions, options?: RelayedConnectionOptions): MethodAndPropDecorator {
   return <M>(target: any, propertyKey: string | symbol) => {
+    let through: ClassValueThunk | undefined
+    
+    if(typeof throughOrOptions === "function") {
+      through = throughOrOptions
+    } else {
+      options = throughOrOptions
+    }
+
     process.nextTick(() => {
       const getterName = `relayField${String(propertyKey)}Getter`
       const capitalized = String(propertyKey).charAt(0).toUpperCase() + String(propertyKey).slice(1)
@@ -22,7 +32,23 @@ export function RelayedConnection (type: ClassValueThunk, through?: ClassValueTh
       const ORM = ormConnection()
       const orm = new ORM()
 
-      target[getterName] = orm.autoRelayFactory(String(propertyKey), () => (target as new () => unknown), type, through as ClassValueThunk)
+      target[getterName] = orm.autoRelayFactory(
+        String(propertyKey),
+        () => (target as new () => unknown),
+        type,
+        through as ClassValueThunk,
+        options
+      )
     })
   }
+}
+
+/**
+ * Options while automatically fetching a connection
+ */
+export interface RelayedConnectionOptions<Entity=any> {
+  /** how to order the returned results */
+  order?: {
+    [P in keyof Entity]?: "ASC" | "DESC" | 1 | -1;
+  }; 
 }

--- a/packages/core/src/orm/orm-connection.abstract.ts
+++ b/packages/core/src/orm/orm-connection.abstract.ts
@@ -1,12 +1,14 @@
+import { RelayedConnectionOptions } from './../decorators/relayed-connection.decorator';
 /* eslint-disable @typescript-eslint/no-type-alias */
 import { ClassValueThunk } from '..'
 import { AugmentedConnection } from '../interfaces/augmented-connection.interface'
 import * as Relay from 'graphql-relay'
 
 export abstract class ORMConnection {
-  public abstract autoRelayFactory<T=any, Y=any>(field: string, self: ClassValueThunk, type: ClassValueThunk<T>, through: ClassValueThunk<Y>): AutoRelayGetter<T, Y>
 
-  public abstract autoRelayFactory<T=any>(field: string, self: ClassValueThunk, type: ClassValueThunk<T>): AutoRelayGetter<T, never>
+  public abstract autoRelayFactory<T=any, Y=any>(field: string, self: ClassValueThunk, type: ClassValueThunk<T>, through?: ClassValueThunk<Y>, options?: RelayedConnectionOptions<Y>): AutoRelayGetter<T, Y>
+  public abstract autoRelayFactory<T=any>(field: string, self: ClassValueThunk, type: ClassValueThunk<T>, through?: undefined, options?: RelayedConnectionOptions<T>): AutoRelayGetter<T, never>
+
 }
 
 export type AutoRelayGetter<T=any, Y=any> =

--- a/packages/type-orm/package-lock.json
+++ b/packages/type-orm/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@auto-relay/typeorm",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -521,9 +521,9 @@
 			"dev": true
 		},
 		"typeorm": {
-			"version": "0.2.18",
-			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.18.tgz",
-			"integrity": "sha512-S553GwtG5ab268+VmaLCN7gKDqFPIzUw0eGMTobJ9yr0Np62Ojfx8j1Oa9bIeh5p7Pz1/kmGabAHoP1MYK05pA==",
+			"version": "0.2.19",
+			"resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.19.tgz",
+			"integrity": "sha512-xKVx/W41zckQ7v8WYcpRhSKpjXDKG/Jgjy0RWvYelR8ZnfyblNRL12jF4P8tIhwXv6l5t01s7HEc9lR+zb6Gtg==",
 			"dev": true,
 			"requires": {
 				"app-root-path": "^2.0.1",

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -5,6 +5,7 @@ import { AutoRelayRunner } from './helpers/auto-relay-runner';
 import { SDLTests } from './suites/sdl';
 import { RelayedQueryTests } from './suites/relayed-query';
 import { RelayedFieldResolverTests } from './suites/relayed-field-resolver';
+import { ConnectionTests } from './suites/connection';
 
 const configs: [string, AutoRelayConfigArgs, () => void | Promise<void>][] = [
   [
@@ -24,9 +25,10 @@ const run = () => {
     })
 
     describe(name, () => {
-      SDLTests(name);
-      RelayedQueryTests(name);
-      RelayedFieldResolverTests(name);
+      SDLTests(name)
+      RelayedQueryTests(name)
+      RelayedFieldResolverTests(name)
+      ConnectionTests(name)
     })
   }
 }

--- a/tests/suites/_typeorm/entities/rate.ts
+++ b/tests/suites/_typeorm/entities/rate.ts
@@ -1,6 +1,5 @@
-import { ObjectType, Field, Int } from 'type-graphql'
+import { ObjectType, Field, Int, ID } from 'type-graphql'
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, CreateDateColumn } from "typeorm"
-
 import { User } from "./user";
 import { Recipe } from "./recipe";
 
@@ -8,14 +7,15 @@ import { Recipe } from "./recipe";
 @ObjectType()
 export class Rate {
   @PrimaryGeneratedColumn()
+  @Field(type => ID)
   readonly id!: number;
 
   @Field(type => Int)
   @Column({ type: "int" })
   value!: number;
 
-  @Field(type => User)
-  @ManyToOne(type => User)
+  @Field(type => User, { nullable: true })
+  @ManyToOne(type => User, { nullable: true })
   user!: User;
 
   @Field()

--- a/tests/suites/_typeorm/entities/recipe.ts
+++ b/tests/suites/_typeorm/entities/recipe.ts
@@ -24,7 +24,10 @@ export class Recipe {
   @RelayedConnection(() => Rate)
   ratings!: Rate[];
 
+  @RelayedConnection(() => Rate, { order: { value: "DESC" } })
+  ratingsByValue!: Rate[]
+
   @Field(type => User)
-  @ManyToOne(type => User)
-  author!: User;
+  @ManyToOne(type => User, { nullable: true })
+  author?: User;
 }

--- a/tests/suites/_typeorm/index.ts
+++ b/tests/suites/_typeorm/index.ts
@@ -8,6 +8,7 @@ import { buildSchema } from 'type-graphql'
 import { TestResolver } from './resolvers/test.resolver'
 import { ApolloServer } from 'apollo-server'
 import { createTestClient } from 'apollo-server-testing'
+import { RecipeResolver } from './resolvers/recipe.resolver';
 
 export async function setUpTypeORM() {
   try {
@@ -17,11 +18,13 @@ export async function setUpTypeORM() {
   await createConnection({
     type: 'sqlite',
     database: ":memory:",
+    synchronize: true,
+    dropSchema: true,
     entities: [User, Recipe, Rate]
   })
 
   const schema = await buildSchema({
-    resolvers: [UserResolver, TestResolver]
+    resolvers: [UserResolver, TestResolver, RecipeResolver]
   })
 
 

--- a/tests/suites/_typeorm/resolvers/recipe.resolver.ts
+++ b/tests/suites/_typeorm/resolvers/recipe.resolver.ts
@@ -1,0 +1,14 @@
+import { Resolver, Query } from "type-graphql";
+import { getRepository, getConnection } from 'typeorm';
+import { Recipe } from '../entities/recipe';
+
+
+@Resolver(() => Recipe)
+export class RecipeResolver {
+
+  @Query(() => [Recipe])
+  public async recipes(): Promise<Recipe[]> {
+    return getRepository(Recipe).find();
+  }
+
+}

--- a/tests/suites/connection.ts
+++ b/tests/suites/connection.ts
@@ -1,0 +1,77 @@
+import { Container } from "typedi"
+import { ApolloServerTestClient } from "apollo-server-testing"
+import { Recipe } from "./_typeorm/entities/recipe"
+import { getConnection, EntityManager } from "typeorm"
+import { Rate } from "./_typeorm/entities/rate"
+import * as faker from 'faker'
+
+export function ConnectionTests(suiteName: string) {
+  let testClient: ApolloServerTestClient
+  let manager: EntityManager
+
+  beforeAll(() => {
+    testClient = Container.get('testServer');
+    manager = getConnection().manager
+  })
+
+  describe(`Connection`, () => {
+    beforeEach(async () => {
+      for (let i = 0; i < 10; i++) {
+        const recipe = manager.create(Recipe, {
+          title: faker.random.words(),
+          description: faker.random.words(),
+        })
+
+        await manager.save(recipe)
+
+        for (let j = 0; j < 10; j++) {
+          await manager.save(
+            manager.create(Rate, {
+              date: faker.date.recent(),
+              value: faker.random.number({ min: 0, max: 10 }),
+              recipe
+            })
+          )
+        }
+      }
+    })
+
+    afterEach(async () => {
+      manager.delete(Recipe, {})
+      manager.delete(Rate, {})
+    })
+
+    describe('Ordering', () => {
+
+      it('Should return everything in the collection sorted by DESC value', async () => {
+        const test = await testClient.query({
+          query: `query { 
+            recipes {
+              id,
+              ratingsByValue {
+                edges {
+                  node {
+                    id,
+                    value
+                  }
+                }
+              }
+            }
+          }
+          `
+        })
+
+        expect(test.errors).toBeUndefined()
+
+        for (let i = 0; i < test.data!.recipes.length; i++) {
+          const recipe = test.data!.recipes[i]
+          let lastValue = 11 // 11 > 10 which is our max rating
+          recipe.ratingsByValue.edges.forEach(({ node }: { node: { id: string, value: string } }) => {
+            expect(lastValue).toBeGreaterThanOrEqual(Number(node.value))
+            lastValue = Number(node.value)
+          })
+        }
+      })
+    })
+  })
+}


### PR DESCRIPTION
Adds optional "ordering" options to `@RelayedConnection` to allow for simple sorting while fetching with relay

closes #6 