### PR TITLE
Feat: Support ordering of nulls values

### DIFF
--- a/docs/sorting/introduction.md
+++ b/docs/sorting/introduction.md
@@ -14,6 +14,7 @@ As to not bloat the main `auto-relay` package, all sorting features have been po
 Currently, the sorting package allows automatically generating all the necessary types for sorting, as well as providing simple API to convert those to input expected by ORMs.
 
 - [x] Sorting by fields that are columns
+- [x] Sorting nulls values first or last
 - [ ] Sorting by custom logic (to be implemented)
 
 ```typescript
@@ -61,6 +62,7 @@ type Query {
 type EntityOrderOptions {
   direction: OrderingDirection = OrderingDirection.ASC
   sort: EntitySortableField
+  nulls: OrderingNullsDirection
 }
 
 enum EntitySortableField {

--- a/docs/sorting/introduction.md
+++ b/docs/sorting/introduction.md
@@ -62,7 +62,7 @@ type Query {
 type EntityOrderOptions {
   direction: OrderingDirection = OrderingDirection.ASC
   sort: EntitySortableField
-  nulls: OrderingNullsDirection
+  nulls: NullsOrdering
 }
 
 enum EntitySortableField {

--- a/packages/sorting/src/graphql/graphql.generator.spec.ts
+++ b/packages/sorting/src/graphql/graphql.generator.spec.ts
@@ -5,7 +5,7 @@ import { FieldResolver, ClassType, Query, buildSchema, registerEnumType } from '
 import { Field, ObjectType, Resolver } from 'type-graphql'
 import { TypeOrmConnection } from "@auto-relay/typeorm"
 import { Container } from 'typedi'
-import { OrderingDirection } from './ordering.input'
+import { OrderingDirection, OrderingNullsDirection } from './ordering.input'
 import { GraphQLEnumTypeConfig } from 'graphql'
 
 jest.mock("@auto-relay/typeorm")
@@ -55,6 +55,10 @@ describe('GQLSortingGenerator', () => {
     registerEnumType(OrderingDirection, {
       name: "OrderingDirection",
       description: "Direction when sorting a column",
+    });
+    registerEnumType(OrderingNullsDirection, {
+      name: "OrderingNullsDirection",
+      description: "Direction of nulls values when sorting a column"
     });
     const schema = createSchema()
     EntityA = schema.EntityA

--- a/packages/sorting/src/graphql/graphql.generator.spec.ts
+++ b/packages/sorting/src/graphql/graphql.generator.spec.ts
@@ -5,7 +5,7 @@ import { FieldResolver, ClassType, Query, buildSchema, registerEnumType } from '
 import { Field, ObjectType, Resolver } from 'type-graphql'
 import { TypeOrmConnection } from "@auto-relay/typeorm"
 import { Container } from 'typedi'
-import { OrderingDirection, OrderingNullsDirection } from './ordering.input'
+import { OrderingDirection, NullsOrdering } from './ordering.input'
 import { GraphQLEnumTypeConfig } from 'graphql'
 
 jest.mock("@auto-relay/typeorm")
@@ -56,10 +56,10 @@ describe('GQLSortingGenerator', () => {
       name: "OrderingDirection",
       description: "Direction when sorting a column",
     });
-    registerEnumType(OrderingNullsDirection, {
-      name: "OrderingNullsDirection",
-      description: "Direction of nulls values when sorting a column"
-    });
+    registerEnumType(NullsOrdering, {
+      name: "NullsOrdering",
+      description: "When sorting a nullable field, possible values on how to sort those null values"
+    })
     const schema = createSchema()
     EntityA = schema.EntityA
     ResolverA = schema.ResolverA

--- a/packages/sorting/src/graphql/ordering.input.spec.ts
+++ b/packages/sorting/src/graphql/ordering.input.spec.ts
@@ -3,7 +3,7 @@ import { PREFIX } from 'auto-relay'
 import { Container } from 'typedi'
 import { getMetadataStorage } from 'type-graphql/dist/metadata/getMetadataStorage'
 import { buildSchema } from 'type-graphql'
-import { orderingValueGQLFactory, OrderingDirection, OrderingNullsDirection } from './ordering.input'
+import { orderingValueGQLFactory, OrderingDirection, NullsOrdering } from './ordering.input'
 import { GraphQLInputField } from 'graphql'
 
 describe('OrderingInput', () => {
@@ -14,9 +14,9 @@ describe('OrderingInput', () => {
       name: "OrderingDirection",
       description: "Direction when sorting a column",
     });
-    registerEnumType(OrderingNullsDirection, {
-      name: "OrderingNullsDirection",
-      description: "Direction of nulls values when sorting a column"
+    registerEnumType(NullsOrdering, {
+      name: "NullsOrdering",
+      description: "When sorting a nullable field, possible values on how to sort those null values"
     })
   })
 
@@ -46,7 +46,7 @@ describe('OrderingInput', () => {
 
     expect(sort.type.toString()).toEqual("TestEnum!")
 
-    expect(nulls.type.toString()).toEqual("OrderingNullsDirection")
+    expect(nulls.type.toString()).toEqual("NullsOrdering")
   })
 
   it('Should re-use ordering if already exists', async () => {

--- a/packages/sorting/src/graphql/ordering.input.spec.ts
+++ b/packages/sorting/src/graphql/ordering.input.spec.ts
@@ -3,7 +3,7 @@ import { PREFIX } from 'auto-relay'
 import { Container } from 'typedi'
 import { getMetadataStorage } from 'type-graphql/dist/metadata/getMetadataStorage'
 import { buildSchema } from 'type-graphql'
-import { orderingValueGQLFactory, OrderingDirection } from './ordering.input'
+import { orderingValueGQLFactory, OrderingDirection, OrderingNullsDirection } from './ordering.input'
 import { GraphQLInputField } from 'graphql'
 
 describe('OrderingInput', () => {
@@ -14,6 +14,10 @@ describe('OrderingInput', () => {
       name: "OrderingDirection",
       description: "Direction when sorting a column",
     });
+    registerEnumType(OrderingNullsDirection, {
+      name: "OrderingNullsDirection",
+      description: "Direction of nulls values when sorting a column"
+    })
   })
 
   it("Should create an InputType with supplied infos", async () => {
@@ -35,11 +39,14 @@ describe('OrderingInput', () => {
     expect(test.name).toEqual("TestabcMyTypeOrderOptions")
     const direction: GraphQLInputField = (test as any).fields.direction
     const sort: GraphQLInputField = (test as any).fields.sort
+    const nulls: GraphQLInputField = (test as any).fields.nulls
 
     expect(direction.type.toString()).toEqual("OrderingDirection")
     expect(direction.defaultValue.toString()).toEqual("ASC")
 
     expect(sort.type.toString()).toEqual("TestEnum!")
+
+    expect(nulls.type.toString()).toEqual("OrderingNullsDirection")
   })
 
   it('Should re-use ordering if already exists', async () => {

--- a/packages/sorting/src/graphql/ordering.input.ts
+++ b/packages/sorting/src/graphql/ordering.input.ts
@@ -8,8 +8,8 @@ export enum OrderingDirection {
 }
 
 export enum OrderingNullsDirection {
-  NULLS_FIRST = 'NULLS FIRST',
-  NULLS_LAST = 'NULLS LAST',
+  FIRST = 'FIRST',
+  LAST = 'LAST',
 }
 
 registerEnumType(OrderingDirection, {

--- a/packages/sorting/src/graphql/ordering.input.ts
+++ b/packages/sorting/src/graphql/ordering.input.ts
@@ -7,10 +7,20 @@ export enum OrderingDirection {
   DESC = 'DESC'
 }
 
+export enum OrderingNullsDirection {
+  NULLS_FIRST = 'NULLS FIRST',
+  NULLS_LAST = 'NULLS LAST',
+}
+
 registerEnumType(OrderingDirection, {
   name: "OrderingDirection",
   description: "Direction when sorting a column (defaults to ASC)",
 });
+
+registerEnumType(OrderingNullsDirection, {
+  name: "OrderingNullsDirection",
+  description: "Direction of nulls values when sorting a column"
+})
 
 /**
  * Create an OrderingInput inputType for graphql based on the given name and
@@ -37,12 +47,14 @@ export function orderingValueGQLFactory(
   // Otherwise generate them
   const namedClass = {
     [className]: class implements OrderingValue {
-      direction?: OrderingDirection;
+      direction?: OrderingDirection
       sort!: StandardEnum
+      nulls?: OrderingNullsDirection
     }
   }
   Field(() => OrderingDirection, { defaultValue: OrderingDirection.ASC })(namedClass[className].prototype, 'direction')
   Field(() => registeredEnum)(namedClass[className].prototype, 'sort')  
+  Field(() => OrderingNullsDirection, { nullable: true })(namedClass[className].prototype, 'nulls')
   ArgsType()(namedClass[className])
   InputType(className)(namedClass[className])
 
@@ -55,6 +67,7 @@ export function orderingValueGQLFactory(
 export interface OrderingValue<T extends StandardEnum<U> = any, U = any> {
   direction?: OrderingDirection
   sort: T
+  nulls?: OrderingNullsDirection
 }
 
 export type StandardEnum<T=any> = {

--- a/packages/sorting/src/graphql/ordering.input.ts
+++ b/packages/sorting/src/graphql/ordering.input.ts
@@ -7,7 +7,7 @@ export enum OrderingDirection {
   DESC = 'DESC'
 }
 
-export enum OrderingNullsDirection {
+export enum NullsOrdering {
   FIRST = 'FIRST',
   LAST = 'LAST',
 }
@@ -17,9 +17,9 @@ registerEnumType(OrderingDirection, {
   description: "Direction when sorting a column (defaults to ASC)",
 });
 
-registerEnumType(OrderingNullsDirection, {
-  name: "OrderingNullsDirection",
-  description: "Direction of nulls values when sorting a column"
+registerEnumType(NullsOrdering, {
+  name: "NullsOrdering",
+  description: "When sorting a nullable field, possible values on how to sort those null values"
 })
 
 /**
@@ -49,12 +49,12 @@ export function orderingValueGQLFactory(
     [className]: class implements OrderingValue {
       direction?: OrderingDirection
       sort!: StandardEnum
-      nulls?: OrderingNullsDirection
+      nulls?: NullsOrdering
     }
   }
   Field(() => OrderingDirection, { defaultValue: OrderingDirection.ASC })(namedClass[className].prototype, 'direction')
   Field(() => registeredEnum)(namedClass[className].prototype, 'sort')  
-  Field(() => OrderingNullsDirection, { nullable: true })(namedClass[className].prototype, 'nulls')
+  Field(() => NullsOrdering, { nullable: true })(namedClass[className].prototype, 'nulls')
   ArgsType()(namedClass[className])
   InputType(className)(namedClass[className])
 
@@ -67,7 +67,7 @@ export function orderingValueGQLFactory(
 export interface OrderingValue<T extends StandardEnum<U> = any, U = any> {
   direction?: OrderingDirection
   sort: T
-  nulls?: OrderingNullsDirection
+  nulls?: NullsOrdering
 }
 
 export type StandardEnum<T=any> = {

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
@@ -63,16 +63,16 @@ describe("SortableFromResolver", () => {
     const test = getSortablesFromResolverData({
       args: {
         order: [
-          { sort: "foo", direction: "DESC", nulls: "NULLS LAST" },
-          { sort: "schemaBar", nulls: "NULLS FIRST" },
+          { sort: "foo", direction: "DESC", nulls: "LAST" },
+          { sort: "schemaBar", nulls: "FIRST" },
         ] as OrderingValue[]
       }
     } as any, resolver, "test")
 
     expect(test).toHaveLength(2)
     expect(test).toContainAllValues([
-      { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: "NULLS LAST" },
-      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: "NULLS FIRST" },
+      { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: "LAST" },
+      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: "FIRST" },
     ] as SortingField[])
   })
 

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
@@ -42,38 +42,42 @@ describe("SortableFromResolver", () => {
     ).toThrow(SortingFieldDoesntExistError)
   })
 
-  it("Should return array of SortingField (without nulls)", () => {
-    const test = getSortablesFromResolverData({
-      args: {
-        order: [
-          { sort: "foo", direction: "DESC" },
-          { sort: "schemaBar" },
-        ] as OrderingValue[]
-      }
-    } as any, resolver, "test")
-
-    expect(test).toHaveLength(2)
-    expect(test).toContainAllValues([
-      { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: undefined },
-      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: undefined },
-    ] as SortingField[])
+  describe('Without using nulls values direction', () => {
+    it("Should return array of SortingField", () => {
+      const test = getSortablesFromResolverData({
+        args: {
+          order: [
+            { sort: "foo", direction: "DESC" },
+            { sort: "schemaBar" },
+          ] as OrderingValue[]
+        }
+      } as any, resolver, "test")
+  
+      expect(test).toHaveLength(2)
+      expect(test).toContainAllValues([
+        { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: undefined },
+        { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: undefined },
+      ] as SortingField[])
+    })
   })
 
-  it("Should return array of SortingField (with nulls)", () => {
-    const test = getSortablesFromResolverData({
-      args: {
-        order: [
-          { sort: "foo", direction: "DESC", nulls: "LAST" },
-          { sort: "schemaBar", nulls: "FIRST" },
-        ] as OrderingValue[]
-      }
-    } as any, resolver, "test")
+  describe('Using nulls values direction', () => {
+    it("Should return array of SortingField", () => {
+      const test = getSortablesFromResolverData({
+        args: {
+          order: [
+            { sort: "foo", direction: "DESC", nulls: "LAST" },
+            { sort: "schemaBar", nulls: "FIRST" },
+          ] as OrderingValue[]
+        }
+      } as any, resolver, "test")
 
-    expect(test).toHaveLength(2)
-    expect(test).toContainAllValues([
-      { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: "LAST" },
-      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: "FIRST" },
-    ] as SortingField[])
+      expect(test).toHaveLength(2)
+      expect(test).toContainAllValues([
+        { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: "LAST" },
+        { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: "FIRST" },
+      ] as SortingField[])
+    })
   })
 
 })

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
@@ -42,7 +42,7 @@ describe("SortableFromResolver", () => {
     ).toThrow(SortingFieldDoesntExistError)
   })
 
-  describe('Without using nulls values direction', () => {
+  describe('Without using nulls ordering', () => {
     it("Should return array of SortingField", () => {
       const test = getSortablesFromResolverData({
         args: {
@@ -61,7 +61,7 @@ describe("SortableFromResolver", () => {
     })
   })
 
-  describe('Using nulls values direction', () => {
+  describe('Using nulls ordering', () => {
     it("Should return array of SortingField", () => {
       const test = getSortablesFromResolverData({
         args: {

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
@@ -42,7 +42,7 @@ describe("SortableFromResolver", () => {
     ).toThrow(SortingFieldDoesntExistError)
   })
 
-  it("Should return array of SortingField", () => {
+  it("Should return array of SortingField (without nulls)", () => {
     const test = getSortablesFromResolverData({
       args: {
         order: [
@@ -54,8 +54,25 @@ describe("SortableFromResolver", () => {
 
     expect(test).toHaveLength(2)
     expect(test).toContainAllValues([
-      { direction: "DESC", name: "foo", schemaName: "foo", type: entity },
-      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity },
+      { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: undefined },
+      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: undefined },
+    ] as SortingField[])
+  })
+
+  it("Should return array of SortingField (with nulls)", () => {
+    const test = getSortablesFromResolverData({
+      args: {
+        order: [
+          { sort: "foo", direction: "DESC", nulls: "NULLS LAST" },
+          { sort: "schemaBar", nulls: "NULLS FIRST" },
+        ] as OrderingValue[]
+      }
+    } as any, resolver, "test")
+
+    expect(test).toHaveLength(2)
+    expect(test).toContainAllValues([
+      { direction: "DESC", name: "foo", schemaName: "foo", type: entity, nulls: "NULLS LAST" },
+      { direction: "ASC", name: "bar", schemaName: "schemaBar", type: entity, nulls: "NULLS FIRST" },
     ] as SortingField[])
   })
 

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.ts
@@ -1,7 +1,7 @@
 import { NotSortableError } from './../errors/not-sortable.error';
 import { AUTORELAY_ENUM_REVERSE_MAP, SortableField } from './../graphql/graphql.generator';
 import { ResolverData, ClassType } from 'type-graphql'
-import { OrderingDirection, OrderingNullsDirection,  OrderingValue } from '../graphql/ordering.input'
+import { OrderingDirection, OrderingValue, NullsOrdering } from '../graphql/ordering.input'
 import { SortingFieldDoesntExistError } from '../errors/sorting-field-no-exists.error';
 
 /**
@@ -43,8 +43,8 @@ export interface SortingField {
   schemaName: string
   /** direction to sort by */
   direction: OrderingDirection
-  /** direction to sort nulls by */
-  nulls?: OrderingNullsDirection
+  /** how the nulls ordering is managed */
+  nulls?: NullsOrdering
   /** type on which this field exists */
   type: ClassType
 }

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.ts
@@ -1,7 +1,7 @@
 import { NotSortableError } from './../errors/not-sortable.error';
 import { AUTORELAY_ENUM_REVERSE_MAP, SortableField } from './../graphql/graphql.generator';
 import { ResolverData, ClassType } from 'type-graphql'
-import { OrderingDirection, OrderingValue } from '../graphql/ordering.input'
+import { OrderingDirection, OrderingNullsDirection,  OrderingValue } from '../graphql/ordering.input'
 import { SortingFieldDoesntExistError } from '../errors/sorting-field-no-exists.error';
 
 /**
@@ -27,7 +27,8 @@ export function getSortablesFromResolverData(
     if (!sortable) throw new SortingFieldDoesntExistError(orderingValue, target, propertyKey)
     return {
       ...sortable,
-      direction: orderingValue.direction ?? OrderingDirection.ASC
+      direction: orderingValue.direction ?? OrderingDirection.ASC,
+      nulls: orderingValue.nulls,
     }
   })
 
@@ -42,6 +43,8 @@ export interface SortingField {
   schemaName: string
   /** direction to sort by */
   direction: OrderingDirection
+  /** direction to sort nulls by */
+  nulls?: OrderingNullsDirection
   /** type on which this field exists */
   type: ClassType
 }

--- a/packages/type-orm/src/decorators/order-options.decorator.ts
+++ b/packages/type-orm/src/decorators/order-options.decorator.ts
@@ -14,7 +14,7 @@ export function OrderOptions<T = any>(prefix?: string) {
 }
 
 export type TypeORMOrdering<Entity = any> = {
-  [P in keyof Entity]?: ("ASC"|"DESC")|{
+  [P in keyof Entity]?: {
     order: "ASC"|"DESC";
     nulls?: "NULLS FIRST"|"NULLS LAST";
   }

--- a/packages/type-orm/src/decorators/order-options.decorator.ts
+++ b/packages/type-orm/src/decorators/order-options.decorator.ts
@@ -14,6 +14,8 @@ export function OrderOptions<T = any>(prefix?: string) {
 }
 
 export type TypeORMOrdering<Entity = any> = {
-  [P in keyof Entity]?: "ASC" | "DESC"
+  [P in keyof Entity]?: ("ASC"|"DESC")|{
+    order: "ASC"|"DESC";
+    nulls?: "NULLS FIRST"|"NULLS LAST";
+  }
 }
-

--- a/packages/type-orm/src/services/sorting.service.spec.ts
+++ b/packages/type-orm/src/services/sorting.service.spec.ts
@@ -33,7 +33,7 @@ describe("TypeORM Sorting Service", () => {
     ])
     typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "foo" })
     const test = service.buildOrderObject({} as any, {} as any, "test", 'test.')
-    expect(test).toStrictEqual({ "test.foo": "ASC" })
+    expect(test).toStrictEqual({ "test.foo": { order: "ASC", nulls: undefined }})
   })
 
   it("Should return db name", () => {
@@ -42,11 +42,11 @@ describe("TypeORM Sorting Service", () => {
     ])
     typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "dbFoo" })
     const test = service.buildOrderObject({} as any, {} as any, "test", '')
-    expect(test).toStrictEqual({ "dbFoo": "ASC" })
+    expect(test).toStrictEqual({ "dbFoo": { order: "ASC", nulls: undefined }})
   })
 
   
-  it("Should use complex ordering form on nulls", () => {
+  it("Should support nulls ordering", () => {
     getSortables.mockReturnValueOnce([
       { name: "foo", schemaName: "foo", type: entity, direction: OrderingDirection.ASC, nulls: OrderingNullsDirection.FIRST },
       { name: "bar", schemaName: "bar", type: entity, direction: OrderingDirection.DESC, nulls: OrderingNullsDirection.LAST },

--- a/packages/type-orm/src/services/sorting.service.spec.ts
+++ b/packages/type-orm/src/services/sorting.service.spec.ts
@@ -48,11 +48,19 @@ describe("TypeORM Sorting Service", () => {
   
   it("Should use complex ordering form on nulls", () => {
     getSortables.mockReturnValueOnce([
-      { name: "foo", schemaName: "foo", type: entity, direction: OrderingDirection.ASC, nulls: OrderingNullsDirection.NULLS_FIRST }
+      { name: "foo", schemaName: "foo", type: entity, direction: OrderingDirection.ASC, nulls: OrderingNullsDirection.FIRST },
+      { name: "bar", schemaName: "bar", type: entity, direction: OrderingDirection.DESC, nulls: OrderingNullsDirection.LAST },
     ])
-    typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "dbFoo" })
+    typeormConnection.getColumnsOfFields.mockReturnValue({ 
+      foo: "dbFoo",
+      bar: "dbBar",
+    })
+
     const test = service.buildOrderObject({} as any, {} as any, "test", '')
-    expect(test).toStrictEqual({ "dbFoo": { order: "ASC", nulls: "NULLS FIRST" }})
+    expect(test).toStrictEqual({ 
+      "dbFoo": { order: "ASC", nulls: "NULLS FIRST" },
+      "dbBar": { order: "DESC", nulls: "NULLS LAST" },
+    })
   })
 
 })

--- a/packages/type-orm/src/services/sorting.service.spec.ts
+++ b/packages/type-orm/src/services/sorting.service.spec.ts
@@ -1,7 +1,7 @@
 import { SortingService } from './sorting.service';
 import { getSortablesFromResolverData } from "@auto-relay/sorting"
 import { TypeOrmConnection } from '../type-orm-connection'
-import { OrderingDirection, OrderingNullsDirection } from '@auto-relay/sorting/graphql/ordering.input'
+import { OrderingDirection, NullsOrdering } from '@auto-relay/sorting/graphql/ordering.input'
 import { Container } from 'typedi'
 
 jest.mock("../type-orm-connection")
@@ -48,8 +48,8 @@ describe("TypeORM Sorting Service", () => {
   
   it("Should support nulls ordering", () => {
     getSortables.mockReturnValueOnce([
-      { name: "foo", schemaName: "foo", type: entity, direction: OrderingDirection.ASC, nulls: OrderingNullsDirection.FIRST },
-      { name: "bar", schemaName: "bar", type: entity, direction: OrderingDirection.DESC, nulls: OrderingNullsDirection.LAST },
+      { name: "foo", schemaName: "foo", type: entity, direction: OrderingDirection.ASC, nulls: NullsOrdering.FIRST },
+      { name: "bar", schemaName: "bar", type: entity, direction: OrderingDirection.DESC, nulls: NullsOrdering.LAST },
     ])
     typeormConnection.getColumnsOfFields.mockReturnValue({ 
       foo: "dbFoo",

--- a/packages/type-orm/src/services/sorting.service.spec.ts
+++ b/packages/type-orm/src/services/sorting.service.spec.ts
@@ -1,7 +1,7 @@
 import { SortingService } from './sorting.service';
 import { getSortablesFromResolverData } from "@auto-relay/sorting"
 import { TypeOrmConnection } from '../type-orm-connection'
-import { OrderingDirection } from '@auto-relay/sorting/graphql/ordering.input'
+import { OrderingDirection, OrderingNullsDirection } from '@auto-relay/sorting/graphql/ordering.input'
 import { Container } from 'typedi'
 
 jest.mock("../type-orm-connection")
@@ -43,6 +43,16 @@ describe("TypeORM Sorting Service", () => {
     typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "dbFoo" })
     const test = service.buildOrderObject({} as any, {} as any, "test", '')
     expect(test).toStrictEqual({ "dbFoo": "ASC" })
+  })
+
+  
+  it("Should use complex ordering form on nulls", () => {
+    getSortables.mockReturnValueOnce([
+      { name: "foo", schemaName: "foo", type: entity, direction: OrderingDirection.ASC, nulls: OrderingNullsDirection.NULLS_FIRST }
+    ])
+    typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "dbFoo" })
+    const test = service.buildOrderObject({} as any, {} as any, "test", '')
+    expect(test).toStrictEqual({ "dbFoo": { order: "ASC", nulls: "NULLS FIRST" }})
   })
 
 })

--- a/packages/type-orm/src/services/sorting.service.ts
+++ b/packages/type-orm/src/services/sorting.service.ts
@@ -37,16 +37,14 @@ export class SortingService {
 
     return sortingFields.reduce((acc: TypeORMOrdering, sortingField) => {
       const dbName = dbColumns[sortingField.name]
-      acc[`${prefix}${dbName}`] = (sortingField.nulls) 
-        // complex ordering form that supports nulls direction
-        ? {
+      acc[`${prefix}${dbName}`] = {
           order: sortingField.direction, 
-          nulls: (sortingField.nulls === "FIRST") 
-            ? `NULLS FIRST` 
-            : `NULLS LAST`
+          nulls: sortingField.nulls && (
+            (sortingField.nulls === "FIRST") 
+                ? `NULLS FIRST` 
+                : `NULLS LAST`
+          )
         }
-        // simple ordering form as a string (ASC|DESC)
-        : sortingField.direction
       return acc
     }, {} as TypeORMOrdering)
 

--- a/packages/type-orm/src/services/sorting.service.ts
+++ b/packages/type-orm/src/services/sorting.service.ts
@@ -25,7 +25,7 @@ export class SortingService {
       name: string, 
       type: ClassType, 
       direction: "ASC" | "DESC", 
-      nulls?: "NULLS FIRST" | "NULLS LAST",
+      nulls?: "FIRST" | "LAST",
     }[] = getSortablesFromResolverData(resolverData, target, propertyKey)
 
     if (!sortingFields.length) return {}
@@ -39,7 +39,12 @@ export class SortingService {
       const dbName = dbColumns[sortingField.name]
       acc[`${prefix}${dbName}`] = (sortingField.nulls) 
         // complex ordering form that supports nulls direction
-        ? {order: sortingField.direction, nulls: sortingField.nulls}
+        ? {
+          order: sortingField.direction, 
+          nulls: (sortingField.nulls === "FIRST") 
+            ? `NULLS FIRST` 
+            : `NULLS LAST`
+        }
         // simple ordering form as a string (ASC|DESC)
         : sortingField.direction
       return acc

--- a/tests/suites/sorting.ts
+++ b/tests/suites/sorting.ts
@@ -25,7 +25,7 @@ export function SortingTests(suiteName: string) {
     it('Should work without errors on a query and get nulls values', async () => {
       const test = await testClient.query({
         query: `query { 
-          sortableEntities(order: [{sort: sortingFoo, nulls: NULLS_FIRST }, { sort: sortingBar, direction: DESC, , nulls: NULLS_LAST }]) 
+          sortableEntities(order: [{sort: sortingFoo, nulls: FIRST }, { sort: sortingBar, direction: DESC, nulls: LAST }]) 
         }
         `
       })

--- a/tests/suites/sorting.ts
+++ b/tests/suites/sorting.ts
@@ -14,18 +14,27 @@ export function SortingTests(suiteName: string) {
     it('Should work without errors on a query', async () => {
       const test = await testClient.query({
         query: `query { 
-          sortableEntities(order: [{sort: sortingFoo}, { sort: sortingBar, direction: DESC }]) 
+          sortableEntities(order: [
+            { sort: sortingFoo }, 
+            { sort: sortingBar, direction: DESC }
+          ]) 
         }
         `
       })
       expect(test.errors).toBeUndefined()
-      expect(JSON.parse(test.data!.sortableEntities)).toStrictEqual({ sortingFoo: "ASC", sortingBar: "DESC" })
+      expect(JSON.parse(test.data!.sortableEntities)).toStrictEqual({ 
+        sortingFoo: { order: "ASC" }, 
+        sortingBar: { order: "DESC" },
+      })
     })
 
-    it('Should work without errors on a query and get nulls values', async () => {
+    it('Should work without errors on a query and get nulls ordering', async () => {
       const test = await testClient.query({
         query: `query { 
-          sortableEntities(order: [{sort: sortingFoo, nulls: FIRST }, { sort: sortingBar, direction: DESC, nulls: LAST }]) 
+          sortableEntities(order: [
+            { sort: sortingFoo, nulls: FIRST }, 
+            { sort: sortingBar, direction: DESC, nulls: LAST }
+          ]) 
         }
         `
       })

--- a/tests/suites/sorting.ts
+++ b/tests/suites/sorting.ts
@@ -21,5 +21,19 @@ export function SortingTests(suiteName: string) {
       expect(test.errors).toBeUndefined()
       expect(JSON.parse(test.data!.sortableEntities)).toStrictEqual({ sortingFoo: "ASC", sortingBar: "DESC" })
     })
+
+    it('Should work without errors on a query and get nulls values', async () => {
+      const test = await testClient.query({
+        query: `query { 
+          sortableEntities(order: [{sort: sortingFoo, nulls: NULLS_FIRST }, { sort: sortingBar, direction: DESC, , nulls: NULLS_LAST }]) 
+        }
+        `
+      })
+      expect(test.errors).toBeUndefined()
+      expect(JSON.parse(test.data!.sortableEntities)).toStrictEqual({ 
+        sortingFoo: { order: "ASC", nulls: "NULLS FIRST" }, 
+        sortingBar: { order: "DESC", nulls: "NULLS LAST" },
+      })
+    })
   })
 }


### PR DESCRIPTION
# What does this PR do ?

Support ordering of nulls values (first|last) into *OrderOptions types

## Addition to generated GraphQL types 

```
# Direction of nulls values when sorting a column
enum OrderNullsDirection {
  FIRST
  LAST
}

input *OrderOptions {
  # ...
  nulls: OrderNullsDirection
}
```

## TypeORMOrdering

Supports nulls using a compatible type of the TypeORM [OrderByCondition](https://github.com/typeorm/typeorm/blob/master/src/find-options/OrderByCondition.ts). 



