### PR TITLE
fix: when nulls is falsy, use the short compatible form of OrderByCondition

### DIFF
--- a/packages/type-orm/src/decorators/order-options.decorator.ts
+++ b/packages/type-orm/src/decorators/order-options.decorator.ts
@@ -13,9 +13,11 @@ export function OrderOptions<T = any>(prefix?: string) {
     )(target, propertyKey, parameterIndex)}
 }
 
+export type TypeORMOrderByConditionValue = ("ASC"|"DESC")|{
+  order: "ASC"|"DESC";
+  nulls?: "NULLS FIRST"|"NULLS LAST";
+}
+
 export type TypeORMOrdering<Entity = any> = {
-  [P in keyof Entity]?: {
-    order: "ASC"|"DESC";
-    nulls?: "NULLS FIRST"|"NULLS LAST";
-  }
+  [P in keyof Entity]?: TypeORMOrderByConditionValue
 }

--- a/packages/type-orm/src/decorators/order-options.decorator.ts
+++ b/packages/type-orm/src/decorators/order-options.decorator.ts
@@ -15,7 +15,7 @@ export function OrderOptions<T = any>(prefix?: string) {
 
 export type TypeORMOrderByConditionValue = ("ASC"|"DESC")|{
   order: "ASC"|"DESC";
-  nulls?: "NULLS FIRST"|"NULLS LAST";
+  nulls: "NULLS FIRST"|"NULLS LAST";
 }
 
 export type TypeORMOrdering<Entity = any> = {

--- a/packages/type-orm/src/services/sorting.service.spec.ts
+++ b/packages/type-orm/src/services/sorting.service.spec.ts
@@ -33,7 +33,7 @@ describe("TypeORM Sorting Service", () => {
     ])
     typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "foo" })
     const test = service.buildOrderObject({} as any, {} as any, "test", 'test.')
-    expect(test).toStrictEqual({ "test.foo": { order: "ASC", nulls: undefined }})
+    expect(test).toStrictEqual({ "test.foo": "ASC" })
   })
 
   it("Should return db name", () => {
@@ -42,7 +42,7 @@ describe("TypeORM Sorting Service", () => {
     ])
     typeormConnection.getColumnsOfFields.mockReturnValue({ foo: "dbFoo" })
     const test = service.buildOrderObject({} as any, {} as any, "test", '')
-    expect(test).toStrictEqual({ "dbFoo": { order: "ASC", nulls: undefined }})
+    expect(test).toStrictEqual({ "dbFoo": "ASC" })
   })
 
   
@@ -60,6 +60,34 @@ describe("TypeORM Sorting Service", () => {
     expect(test).toStrictEqual({ 
       "dbFoo": { order: "ASC", nulls: "NULLS FIRST" },
       "dbBar": { order: "DESC", nulls: "NULLS LAST" },
+    })
+  })
+
+  describe('buildOrderByConditionValue', () => {
+    it("Should returns ASC", () => {
+      const result = service.buildOrderByConditionValue({direction: "ASC"})
+      expect(result).toEqual("ASC")
+    })
+
+    it("Should returns DESC", () => {
+      const result = service.buildOrderByConditionValue({direction: "DESC"})
+      expect(result).toEqual("DESC")
+    })
+
+    it("Should not care about undefined nulls values", () => {
+      const withUndefined = service.buildOrderByConditionValue({direction: "ASC", nulls: undefined})
+
+      expect(withUndefined).toEqual("ASC")
+    })
+
+    it("Should returns a NULLS FIRST", () => {
+      const result = service.buildOrderByConditionValue({direction: "ASC", nulls: "FIRST"})
+      expect(result).toEqual({order: "ASC", nulls: "NULLS FIRST"})
+    })
+
+    it("Should returns a NULLS LAST", () => {
+      const result = service.buildOrderByConditionValue({direction: "DESC", nulls: "LAST"})
+      expect(result).toEqual({order: "DESC", nulls: "NULLS LAST"})
     })
   })
 

--- a/packages/type-orm/src/services/sorting.service.spec.ts
+++ b/packages/type-orm/src/services/sorting.service.spec.ts
@@ -65,28 +65,28 @@ describe("TypeORM Sorting Service", () => {
 
   describe('buildOrderByConditionValue', () => {
     it("Should returns ASC", () => {
-      const result = service.buildOrderByConditionValue({direction: "ASC"})
+      const result = service["buildOrderByConditionValue"]({direction: "ASC"})
       expect(result).toEqual("ASC")
     })
 
     it("Should returns DESC", () => {
-      const result = service.buildOrderByConditionValue({direction: "DESC"})
+      const result = service["buildOrderByConditionValue"]({direction: "DESC"})
       expect(result).toEqual("DESC")
     })
 
     it("Should not care about undefined nulls values", () => {
-      const withUndefined = service.buildOrderByConditionValue({direction: "ASC", nulls: undefined})
+      const withUndefined = service["buildOrderByConditionValue"]({direction: "ASC", nulls: undefined})
 
       expect(withUndefined).toEqual("ASC")
     })
 
     it("Should returns a NULLS FIRST", () => {
-      const result = service.buildOrderByConditionValue({direction: "ASC", nulls: "FIRST"})
+      const result = service["buildOrderByConditionValue"]({direction: "ASC", nulls: "FIRST"})
       expect(result).toEqual({order: "ASC", nulls: "NULLS FIRST"})
     })
 
     it("Should returns a NULLS LAST", () => {
-      const result = service.buildOrderByConditionValue({direction: "DESC", nulls: "LAST"})
+      const result = service["buildOrderByConditionValue"]({direction: "DESC", nulls: "LAST"})
       expect(result).toEqual({order: "DESC", nulls: "NULLS LAST"})
     })
   })

--- a/packages/type-orm/src/services/sorting.service.ts
+++ b/packages/type-orm/src/services/sorting.service.ts
@@ -1,6 +1,6 @@
 import { ClassType, ResolverData } from 'type-graphql'
 import { Container, Service } from "typedi"
-import { TypeORMOrdering } from '../decorators/order-options.decorator'
+import { TypeORMOrdering, TypeORMOrderByConditionValue } from '../decorators/order-options.decorator'
 import { TypeOrmConnection } from '../type-orm-connection'
 
 @Service()
@@ -37,17 +37,24 @@ export class SortingService {
 
     return sortingFields.reduce((acc: TypeORMOrdering, sortingField) => {
       const dbName = dbColumns[sortingField.name]
-      acc[`${prefix}${dbName}`] = {
-          order: sortingField.direction, 
-          nulls: sortingField.nulls && (
-            (sortingField.nulls === "FIRST") 
-                ? `NULLS FIRST` 
-                : `NULLS LAST`
-          )
-        }
+      acc[`${prefix}${dbName}`] = this.buildOrderByConditionValue(sortingField)
       return acc
     }, {} as TypeORMOrdering)
 
+  }
+
+  public buildOrderByConditionValue(sortingField: {
+    direction: "ASC" | "DESC", 
+    nulls?: "FIRST" | "LAST",
+  }): TypeORMOrderByConditionValue {
+    if(!sortingField.nulls){
+      return sortingField.direction
+    }
+
+    return {
+      order: sortingField.direction,
+      nulls: (sortingField.nulls === "FIRST") ? "NULLS FIRST" : "NULLS LAST"
+    }
   }
 
 }

--- a/packages/type-orm/src/services/sorting.service.ts
+++ b/packages/type-orm/src/services/sorting.service.ts
@@ -43,7 +43,15 @@ export class SortingService {
 
   }
 
-  public buildOrderByConditionValue(sortingField: {
+  /**
+   * Build the correct TypeORMOrderByConditionValue matching the internal TypeORM OrderByCondition type
+   * When nulls is not provided, it uses the short form: `("ASC"|"DESC")`
+   * When nulls is provided, it uses the long form: `{order, nulls}`
+   * 
+   * @param sortingField The SortingField to build
+   * @returns TypeORMOrderByConditionValue
+   */
+  protected buildOrderByConditionValue(sortingField: {
     direction: "ASC" | "DESC", 
     nulls?: "FIRST" | "LAST",
   }): TypeORMOrderByConditionValue {

--- a/tests/suites/sorting.ts
+++ b/tests/suites/sorting.ts
@@ -23,8 +23,8 @@ export function SortingTests(suiteName: string) {
       })
       expect(test.errors).toBeUndefined()
       expect(JSON.parse(test.data!.sortableEntities)).toStrictEqual({ 
-        sortingFoo: { order: "ASC" }, 
-        sortingBar: { order: "DESC" },
+        sortingFoo: "ASC", 
+        sortingBar: "DESC",
       })
     })
 


### PR DESCRIPTION
# What does this PR do ?

Following the discovery of [this bug](https://github.com/typeorm/typeorm/issues/8103), we are making support for the short form of OrderByCondition

