### PR TITLE
fix: use Int instead of Float for inline RelayedConnection args

### DIFF
--- a/packages/core/src/graphql/dynamic-object.factory.ts
+++ b/packages/core/src/graphql/dynamic-object.factory.ts
@@ -2,7 +2,7 @@ import { AutoRelayConfig, PAGINATION_OBJECT, PREFIX, CONNECTION_BASE_OBJECT } fr
 import { RelayedConnectionOptions } from './../decorators/relayed-connection.decorator';
 import { Service, Container } from 'typedi'
 import { TypeValue, ClassValueThunk } from '../types/types'
-import { Field, ObjectType, Arg, ClassType } from 'type-graphql'
+import { Field, ObjectType, Arg, ClassType, Int } from 'type-graphql'
 import * as Relay from 'graphql-relay'
 
 /**
@@ -63,9 +63,9 @@ export class DynamicObjectFactory {
     // And we ensure our target[getterName] is recognized by GQL under target{}
     Reflect.defineMetadata('design:paramtypes', [String, Number, String, Number], target, functionName)
     Arg('after', () => String, { nullable: true })(target, functionName, 0)
-    Arg('first', () => Number, { nullable: true })(target, functionName, 1)
+    Arg('first', () => Int, { nullable: true })(target, functionName, 1)
     Arg('before', () => String, { nullable: true })(target, functionName, 2)
-    Arg('last', () => Number, { nullable: true })(target, functionName, 3)
+    Arg('last', () => Int, { nullable: true })(target, functionName, 3)
     Field(() => Connection, { name: `${String(sdlName)}`, ...fieldOptions })(target, functionName, { value: true })
   }
 

--- a/tests/suites/sdl.ts
+++ b/tests/suites/sdl.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, GraphQLField, GraphQLObjectType, GraphQLObjectTypeConfig, GraphQLArgument, GraphQLFieldConfigMap } from 'graphql';
+import { GraphQLSchema, GraphQLField, GraphQLObjectType, GraphQLObjectTypeConfig, GraphQLArgument, GraphQLFieldConfigMap, GraphQLNamedType } from 'graphql';
 import Container from 'typedi';
 export function SDLTests(suiteName: string) {
 
@@ -49,6 +49,31 @@ export function SDLTests(suiteName: string) {
     })
 
     describe('RelayedConnection', () => {
+      
+      describe('Types', () => {
+
+        it('Should add inline relay arguments', () => {
+          const recipe = schema.getType('Recipe') as GraphQLObjectType
+          const field = recipe.getFields()['ratings']
+  
+          const first = field.args.find((a) => a.name === 'first');
+          const last = field.args.find((a) => a.name === 'last');
+          const before = field.args.find((a) => a.name === 'before');
+          const after = field.args.find((a) => a.name === 'after');
+  
+          const checkArg = (expectedType: string, arg?: GraphQLArgument) => {
+            expect(arg).toBeTruthy();
+            expect(arg!.type.toString()).toEqual(expectedType);
+          }
+  
+          checkArg('Int', first)
+          checkArg('Int', last)
+          checkArg('String', before)
+          checkArg('String', after)
+        })
+
+      })
+
     })
 
     describe('RelayedQuery', () => {


### PR DESCRIPTION
BREAKING CHANGE:
When using RelayedConnection, first/last are now Int instead of Float
as per relay spec

fixes #75