### PR TITLE
feature: add support for abstracts

### DIFF
--- a/packages/core/src/graphql/dynamic-object.factory.ts
+++ b/packages/core/src/graphql/dynamic-object.factory.ts
@@ -1,8 +1,8 @@
 import { AutoRelayConfig, PAGINATION_OBJECT, PREFIX, CONNECTION_BASE_OBJECT } from './../services/auto-relay-config.service';
 import { RelayedConnectionOptions } from './../decorators/relayed-connection.decorator';
 import { Service, Container } from 'typedi'
-import { TypeValue, ClassValueThunk } from '../types/types'
-import { Field, ObjectType, Arg, ClassType, Int } from 'type-graphql'
+import { TypeValue, ClassValueThunk, ClassType } from '../types/types'
+import { Field, ObjectType, Arg, Int } from 'type-graphql'
 import * as Relay from 'graphql-relay'
 
 /**

--- a/packages/core/src/orm/orm-connection.abstract.ts
+++ b/packages/core/src/orm/orm-connection.abstract.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-type-alias */
-import { ClassType } from 'type-graphql'
 import { RelayedConnectionOptions } from './../decorators/relayed-connection.decorator';
 import { ClassValueThunk } from '..'
 import { AugmentedConnection } from '../interfaces/augmented-connection.interface'

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-type-alias */
-import { ClassType } from 'type-graphql'
 import { GraphQLScalarType } from 'graphql'
 
+export type ClassType<T = any> = abstract new (...args: any[]) => T;
 export type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFunction | void;
 export type PropertyDecorator = (target: Object, propertyKey: string | symbol) => void;
 export type MethodDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void;

--- a/packages/core/tests/dynamic-object.test.ts
+++ b/packages/core/tests/dynamic-object.test.ts
@@ -6,7 +6,7 @@ import { ObjectTypeDefinitionNode, GraphQLNamedType, GraphQLObjectType, GraphQLS
 import { getMetadataStorage } from "type-graphql/dist/metadata/getMetadataStorage"
 import { getFieldOfObjectType, getConfigOfObjectType } from "./_.helper";
 import Container from 'typedi';
-import { ClassType } from 'type-graphql';
+import { ClassType } from "auto-relay";
 
 const basicSchema = () => {
   @TGQL.ObjectType()

--- a/packages/sorting/src/errors/not-sortable.error.ts
+++ b/packages/sorting/src/errors/not-sortable.error.ts
@@ -1,4 +1,4 @@
-import { ClassType } from 'type-graphql';
+import { ClassType } from "auto-relay";
 
 export class NotSortableError extends Error {
   constructor(target: ClassType, propertyKey: string) {

--- a/packages/sorting/src/graphql/graphql.generator.spec.ts
+++ b/packages/sorting/src/graphql/graphql.generator.spec.ts
@@ -1,7 +1,7 @@
-import { ORMConnection, ORM_CONNECTION } from 'auto-relay'
+import { ORMConnection, ORM_CONNECTION, ClassType } from 'auto-relay'
 import { GQLSortingGenerator, AUTORELAY_ENUM_REVERSE_MAP } from './graphql.generator'
 import { getMetadataStorage } from 'type-graphql/dist/metadata/getMetadataStorage'
-import { FieldResolver, ClassType, Query, buildSchema, registerEnumType } from 'type-graphql'
+import { FieldResolver, Query, buildSchema, registerEnumType } from 'type-graphql'
 import { Field, ObjectType, Resolver } from 'type-graphql'
 import { TypeOrmConnection } from "@auto-relay/typeorm"
 import { Container } from 'typedi'

--- a/packages/sorting/src/graphql/graphql.generator.ts
+++ b/packages/sorting/src/graphql/graphql.generator.ts
@@ -1,7 +1,7 @@
 import { registerEnumType } from 'type-graphql';
-import { ClassType, Arg } from 'type-graphql'
+import { Arg } from 'type-graphql'
 import { Container, Service } from "typedi"
-import { ORMConnection, ORM_CONNECTION } from 'auto-relay'
+import { ORMConnection, ORM_CONNECTION, ClassType } from 'auto-relay'
 import { getMetadataStorage } from 'type-graphql/dist/metadata/getMetadataStorage'
 import { FieldMetadata, ResolverClassMetadata, FieldResolverMetadata } from 'type-graphql/dist/metadata/definitions'
 import { OrderingValue, orderingValueGQLFactory, StandardEnum } from './ordering.input'

--- a/packages/sorting/src/graphql/ordering.input.ts
+++ b/packages/sorting/src/graphql/ordering.input.ts
@@ -1,6 +1,6 @@
 import { Container } from 'typedi'
-import { InputType, ClassType, Field, registerEnumType, ArgsType } from "type-graphql"
-import { PREFIX } from 'auto-relay'
+import { InputType, Field, registerEnumType, ArgsType } from "type-graphql"
+import { ClassType, PREFIX} from 'auto-relay'
 
 export enum OrderingDirection {
   ASC = 'ASC',

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.spec.ts
@@ -1,9 +1,9 @@
 import { SortingFieldDoesntExistError } from './../errors/sorting-field-no-exists.error';
-import { ClassType } from 'type-graphql'
 import { NotSortableError } from './../errors/not-sortable.error'
 import { getSortablesFromResolverData, SortingField } from "./sortable-from-resolver.helper"
 import { AUTORELAY_ENUM_REVERSE_MAP } from '../graphql/graphql.generator'
 import { OrderingValue } from '../graphql/ordering.input'
+import { ClassType } from "auto-relay";
 
 describe("SortableFromResolver", () => {
 

--- a/packages/sorting/src/helpers/sortable-from-resolver.helper.ts
+++ b/packages/sorting/src/helpers/sortable-from-resolver.helper.ts
@@ -1,8 +1,9 @@
 import { NotSortableError } from './../errors/not-sortable.error';
 import { AUTORELAY_ENUM_REVERSE_MAP, SortableField } from './../graphql/graphql.generator';
-import { ResolverData, ClassType } from 'type-graphql'
+import { ResolverData } from 'type-graphql'
 import { OrderingDirection, OrderingValue, NullsOrdering } from '../graphql/ordering.input'
 import { SortingFieldDoesntExistError } from '../errors/sorting-field-no-exists.error';
+import { ClassType } from "auto-relay";
 
 /**
  * Returns all the sorting fields being used in a given query/field resolver

--- a/packages/type-orm/src/services/sorting.service.ts
+++ b/packages/type-orm/src/services/sorting.service.ts
@@ -1,7 +1,8 @@
-import { ClassType, ResolverData } from 'type-graphql'
+import { ResolverData } from 'type-graphql'
 import { Container, Service } from "typedi"
 import { TypeORMOrdering, TypeORMOrderByConditionValue } from '../decorators/order-options.decorator'
 import { TypeOrmConnection } from '../type-orm-connection'
+import { ClassType } from "auto-relay";
 
 @Service()
 export class SortingService {

--- a/packages/type-orm/src/type-orm-connection.ts
+++ b/packages/type-orm/src/type-orm-connection.ts
@@ -1,5 +1,13 @@
-import { ClassType } from 'type-graphql';
-import { ORMConnection, ClassValueThunk, AutoRelayGetter, AugmentedConnection, LimitOffsetPagingService, augmentedConnection, RelayedConnectionOptions } from 'auto-relay'
+import {
+  ORMConnection,
+  ClassValueThunk,
+  AutoRelayGetter,
+  AugmentedConnection,
+  LimitOffsetPagingService,
+  augmentedConnection,
+  RelayedConnectionOptions,
+  ClassType
+} from 'auto-relay'
 import { Container, Service } from 'typedi'
 import { getConnection, EntityMetadata, FindManyOptions, BaseEntity, getMetadataArgsStorage } from 'typeorm'
 import { RelationMetadata } from 'typeorm/metadata/RelationMetadata'


### PR DESCRIPTION
Instead of using the type `ClassType` from `type-graphql`, add our own version that supports the `abstract` classes