### PR TITLE
fix: add missing peerDependencies for reflect-metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
   "peerDependencies": {
     "graphql": "^15.3.0",
     "graphql-relay": "^0.8.0",
+    "reflect-metadata": "^0.1.13",
     "type-graphql": "^1.0.0"
   },
   "engines": {


### PR DESCRIPTION
I encountered this issue while migrating to yarn 3 from v1
![image](https://user-images.githubusercontent.com/3009753/161246976-6469ece9-d403-4e5a-b011-91d3c0ab199f.png)

Temporary fix in `.yarnrc.yml`:
```yml
packageExtensions:
  'auto-relay@*':
    peerDependencies:
      'reflect-metadata': '^0.1.13'
```